### PR TITLE
FFWEB-2735: Create preview product export endpoint

### DIFF
--- a/src/Controller/Adminhtml/Export/Preview.php
+++ b/src/Controller/Adminhtml/Export/Preview.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Controller\Adminhtml\Export;
+
+use Factfinder\Export\Api\StreamInterface;
+use Factfinder\Export\Model\Export\FeedFactory;
+use Factfinder\Export\Model\Stream\Json as JsonStream;
+use Factfinder\Export\Utilities\Validator\ExportPreviewValidator;
+use Magento\Backend\App\Action;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\Result\JsonFactory;
+
+class Preview extends Action
+{
+    private RequestInterface $request;
+
+    public function __construct(
+        Action\Context $context,
+        private readonly JsonFactory $jsonResultFactory,
+        private readonly FeedFactory $feedGeneratorFactory,
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly ConfigurableType $configurableType
+    ) {
+        parent::__construct($context);
+        $this->request = $context->getRequest();
+    }
+
+    public function execute(): Json
+    {
+        $response = $this->jsonResultFactory->create();
+
+        try {
+            $entityId = (int) $this->request->getParam('entityId', 0);
+            (new ExportPreviewValidator($this->productRepository, $this->configurableType, $entityId))->validate();
+
+            return $response->setData($this->getExportData($entityId));
+        } catch (\Throwable $e) {
+            return $response->setData(['message' => $e->getMessage()]);
+        }
+    }
+
+    public function getExportData(int $entityId): array
+    {
+        $feedType = 'exportPreviewProduct';
+        $stream = new JsonStream();
+        $this->feedGeneratorFactory->create($feedType, ['entityId' => $entityId])->generate($stream);
+        $items = $this->getItems($stream);
+
+        return [
+            'totalRecords' => count($items),
+            'items' => $items,
+        ];
+    }
+
+    private function getItems(StreamInterface $stream): array
+    {
+        $content = json_decode($stream->getContent(), true);
+
+        return array_splice($content, 1, count($content));
+    }
+}

--- a/src/Test/Unit/Utilities/Validator/ExportPreviewValidatorTest.php
+++ b/src/Test/Unit/Utilities/Validator/ExportPreviewValidatorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Test\Unit\Utilities\Validator;
+
+use Factfinder\Export\Exception\ExportPreviewValidationException;
+use Factfinder\Export\Utilities\Validator\ExportPreviewValidator;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers ExportPreviewValidator
+ */
+class ExportPreviewValidatorTest extends TestCase
+{
+    private ConfigurableType|MockObject $configurableType;
+    private ProductRepositoryInterface|MockObject $repository;
+
+    protected function setUp(): void
+    {
+        $this->configurableType = $this->createMock(ConfigurableType::class);
+        $this->repository = $this->createMock(ProductRepositoryInterface::class);
+    }
+
+    public function testShouldThrowExceptionWhenGivenEntityIdIsInvalid()
+    {
+        // Expect & Given
+        $entityIds = [0, 'something', null, '', false];
+
+        foreach ($entityIds as $entityId) {
+            $this->expectException(ExportPreviewValidationException::class);
+            $this->expectExceptionMessage(sprintf('Product will not be exported. Reason: Product with ID "%s" does not exist.', (int) $entityId));
+        }
+
+        // When & Then
+        foreach ($entityIds as $entityId) {
+            $validator = new ExportPreviewValidator($this->repository, $this->configurableType, $entityId);
+            $validator->validate();
+        }
+    }
+
+    public function testShouldThrowExceptionWhenProductWithGivenEntityIdDoesNotExist()
+    {
+        // Expect & Given
+        $entityId = 94;
+        $this->expectException(ExportPreviewValidationException::class);
+        $this->expectExceptionMessage(sprintf('Product will not be exported. Reason: Product with ID "%s" does not exist.', $entityId));
+
+        // When
+        $validator = new ExportPreviewValidator($this->repository, $this->configurableType, $entityId);
+
+        // Then
+        $validator->validate();
+    }
+
+    public function testShouldThrowExceptionWhenProductIsNotAvailable()
+    {
+        // Expect
+        $entityId = 2;
+        $product = $this->createMock(Product::class);
+        $product->method('getName')->willReturn('Bike');
+        $product->method('getId')->willReturn($entityId);
+        $product->method('isAvailable')->willReturn(false);
+        $repository = $this->createConfiguredMock(ProductRepositoryInterface::class, ['getById' => $product]);
+        $this->expectException(ExportPreviewValidationException::class);
+        $this->expectExceptionMessage(sprintf('Product will not be exported. Reason: Product "%s" (ID: %s) is not enabled.', $product->getName(), $product->getId()));
+
+        // When
+        $validator = new ExportPreviewValidator($repository, $this->configurableType, $entityId);
+
+        // Then
+        $validator->validate();
+    }
+
+    public function testShouldThrowExceptionWhenProductIsNotVariantAndVisibilityIsSetToNotVisibleIndividually()
+    {
+        // Expect & Given
+        $entityId = 3;
+        $product = $this->createMock(Product::class);
+        $product->method('getName')->willReturn('Bike');
+        $product->method('getId')->willReturn($entityId);
+        $product->method('getVisibility')->willReturn(Visibility::VISIBILITY_NOT_VISIBLE);
+        $configurableType = $this->createMock(ConfigurableType::class);
+        $configurableType->method('getParentIdsByChild')->willReturn([]);
+        $repository = $this->createConfiguredMock(ProductRepositoryInterface::class, ['getById' => $product]);
+        $this->expectException(ExportPreviewValidationException::class);
+        $this->expectExceptionMessage(sprintf('Product will not be exported. Reason: Product "%s" (ID: %s) has "Visibility" set to "Not Visible Individually".', $product->getName(), $product->getId()));
+
+        // When
+        $validator = new ExportPreviewValidator($repository, $configurableType, $entityId);
+
+        // Then
+        $validator->validate();
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Factfinder\Export\Api\ExporterInterface" type="Factfinder\Export\Model\Exporter" />
+    <preference for="Factfinder\Export\Api\Filter\FilterInterface" type="Factfinder\Export\Model\Filter\TextFilter" />
+    <preference for="Factfinder\Export\Api\StreamInterface" type="Factfinder\Export\Model\Stream\Csv" />
+
+    <type name="Factfinder\Export\Model\Export\Catalog\ExportPreviewDataProvider">
+        <arguments>
+            <argument name="productFields" xsi:type="array">
+                <item name="CategoryPath" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\CategoryPath</item>
+                <item name="Brand" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\Brand</item>
+                <item name="FilterAttributes" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\FilterAttributes</item>
+                <item name="NumericalAttributes" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\NumericalAttributes</item>
+            </argument>
+            <argument name="entityTypes" xsi:type="array">
+                <item name="simple" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
+                <item name="configurable" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\ConfigurableDataProvider</item>
+                <item name="grouped" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\GroupedDataProvider</item>
+                <item name="bundle" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\BundleDataProvider</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Factfinder\Export\Model\Export\FeedFactory">
+        <arguments>
+            <argument name="feedPool" xsi:type="array">
+                <item name="exportPreviewProduct" xsi:type="array">
+                    <item xsi:type="string" name="generator">Factfinder\Export\Model\Export\ExportPreviewProductFeed</item>
+                    <item xsi:type="string" name="dataProvider">Factfinder\Export\Model\Export\Catalog\ExportPreviewDataProvider</item>
+                    <item xsi:type="string" name="fieldProvider">Factfinder\Export\Model\Export\Catalog\FieldProvider</item>
+                </item>
+            </argument>
+        </arguments>
+    </type>
+    <virtualType name="Factfinder\Export\Model\Export\ExportPreviewProductFeed" type="Factfinder\Export\Model\Export\CatalogFeed" />
+    <virtualType name="Factfinder\Export\Model\Export\CatalogFeed" type="Factfinder\Export\Model\Export\Feed">
+        <arguments>
+            <argument name="columns" xsi:type="array">
+                <item name="ProductNumber" xsi:type="string">ProductNumber</item>
+                <item name="Master" xsi:type="string">Master</item>
+                <item name="Name" xsi:type="string">Name</item>
+                <item name="Description" xsi:type="string">Description</item>
+                <item name="Short" xsi:type="string">Short</item>
+                <item name="Deeplink" xsi:type="string">Deeplink</item>
+                <item name="Price" xsi:type="string">Price</item>
+                <item name="Brand" xsi:type="string">Brand</item>
+                <item name="Availability" xsi:type="string">Availability</item>
+                <item name="MagentoId" xsi:type="string">MagentoId</item>
+                <item name="ImageURL" xsi:type="string">ImageURL</item>
+                <item name="CategoryPath" xsi:type="string">CategoryPath</item>
+                <item name="FilterAttributes" xsi:type="string">FilterAttributes</item>
+                <item name="HasVariants" xsi:type="string">HasVariants</item>
+                <item name="NumericalAttributes" xsi:type="string">NumericalAttributes</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Factfinder\Export\Model\Export\Catalog\ProductField\Brand" type="Factfinder\Export\Model\Export\Catalog\ProductField\GenericField">
+        <arguments>
+            <argument name="attributeCode" xsi:type="string">manufacturer</argument>
+        </arguments>
+    </virtualType>
+</config>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-2735
- Description:
    - Create preview product export endpoint
- Tested with Magento editions/versions:
    - 2.4.6
- Tested with PHP versions:
    - 8.1
