### PR TITLE
FFWEB-2735: Add export preview button for product form

### DIFF
--- a/src/Block/Adminhtml/Product/Edit/Button/ExportPreview.php
+++ b/src/Block/Adminhtml/Product/Edit/Button/ExportPreview.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Block\Adminhtml\Product\Edit\Button;
+
+use Magento\Catalog\Block\Adminhtml\Product\Edit\Button\Generic;
+
+class ExportPreview extends Generic
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getButtonData(): array
+    {
+        $url = $this->getUrl(
+            'factfinder-export/export/preview',
+            ['entityId' => (int) $this->context->getRequestParam('id', 0)]
+        );
+
+        return [
+            'label' => __('Product Export Preview'),
+            'class' => 'action-secondary',
+            'sort_order' => 25,
+            'on_click' => sprintf("window.open('%s', '_blank');", $url),
+        ];
+    }
+}

--- a/src/view/adminhtml/ui_component/product_form.xml
+++ b/src/view/adminhtml/ui_component/product_form.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="buttons" xsi:type="array">
+            <item name="factfinder-export-preview" xsi:type="string">Factfinder\Export\Block\Adminhtml\Product\Edit\Button\ExportPreview</item>
+        </item>
+    </argument>
+</form>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-2735
- Description:
    - Add export preview button for product form
- Tested with Magento editions/versions:
    - 2.4.6
- Tested with PHP versions:
    -  8.1
