### PR TITLE
FFWEB-2738: Create CLI export for products

### DIFF
--- a/src/Console/Command/Export.php
+++ b/src/Console/Command/Export.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Console\Command;
+
+use Factfinder\Export\Model\Api\PushImport;
+use Factfinder\Export\Model\Config\CommunicationConfig;
+use Factfinder\Export\Model\Export\FeedFactory as FeedGeneratorFactory;
+use Factfinder\Export\Model\FtpUploader;
+use Factfinder\Export\Model\StoreEmulation;
+use Factfinder\Export\Model\Stream\Csv;
+use Factfinder\Export\Service\FeedFileService;
+use Magento\Framework\App\State;
+use Magento\Framework\Filesystem;
+use Magento\Store\Model\StoreManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Export extends Command
+{
+
+    public function __construct(
+        private readonly StoreManagerInterface $storeManager,
+        private readonly FeedGeneratorFactory $feedGeneratorFactory,
+        private readonly StoreEmulation $storeEmulation,
+        private readonly FtpUploader $ftpUploader,
+        private readonly CommunicationConfig $communicationConfig,
+        private readonly PushImport $pushImport,
+        private readonly State $state,
+        private readonly FeedFileService $feedFileService,
+        private readonly Filesystem $filesystem,
+    ) {
+        parent::__construct();
+    }
+    protected function configure(): void
+    {
+        $this->setName('factfinderexport:export')->setDescription('Export feed data as CSV file');;
+        $this->addArgument('type', InputArgument::REQUIRED, 'type of data to be exported. Possible values are : product, cms');
+        $this->addOption('store', 's', InputOption::VALUE_OPTIONAL, 'Store ID or Store Code');
+        $this->addOption('upload', 'u', InputOption::VALUE_NONE, 'Upload feed via FTP');
+        $this->addOption('push-import', 'i', InputOption::VALUE_NONE, 'Push Import');
+
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->state->setAreaCode('frontend');
+        $storeIds = $this->getStoreIds((int) $input->getOption('store'));
+        $type = $input->getArgument('type');
+
+        if (count($storeIds) === 0) {
+            $output->writeln('There is no integration enabled for any store');
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($storeIds as $storeId) {
+            $this->storeEmulation->runInStore($storeId, function () use ($storeId, $input, $output, $type) {
+                $filename = $this->feedFileService->getFeedExportFilename($type, $this->communicationConfig->getChannel($storeId));
+                $stream = new Csv($this->filesystem, "factfinder/$filename");
+                $path = $this->feedFileService->getExportPath($filename);
+
+                $this->feedGeneratorFactory->create($type)->generate($stream);
+                $output->writeln("Store {$storeId}: File {$path} has been generated.");
+
+                if ($input->getOption('upload')) {
+                    $this->ftpUploader->upload($filename, $stream);
+                    $output->writeln("Store {$storeId}: File {$filename} has been uploaded to FTP.");
+                }
+
+                if ($input->getOption('push-import') && $this->pushImport->execute((int) $storeId)) {
+                    $output->writeln("Store {$storeId}: Push Import for File {$filename} has been triggered.");
+                }
+            });
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function getStoreIds(int $storeId): array
+    {
+        $storeIds = array_map(
+            fn ($store) => (int) $store->getId(),
+            $storeId ? [$this->storeManager->getStore($storeId)] : $this->storeManager->getStores()
+        );
+
+        return array_filter($storeIds, [$this->communicationConfig, 'isChannelEnabled']);
+    }
+}

--- a/src/Console/Command/Export.php
+++ b/src/Console/Command/Export.php
@@ -20,6 +20,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class Export extends Command
 {
 
@@ -38,7 +41,8 @@ class Export extends Command
     }
     protected function configure(): void
     {
-        $this->setName('factfinderexport:export')->setDescription('Export feed data as CSV file');;
+        $this->setName('factfinderexport:export');
+        $this->setDescription('Export feed data as CSV file');
         $this->addArgument('type', InputArgument::REQUIRED, 'type of data to be exported. Possible values are : product, cms');
         $this->addOption('store', 's', InputOption::VALUE_OPTIONAL, 'Store ID or Store Code');
         $this->addOption('upload', 'u', InputOption::VALUE_NONE, 'Upload feed via FTP');

--- a/src/Model/Api/PushImport.php
+++ b/src/Model/Api/PushImport.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Api;
+
+use Factfinder\Export\Model\Config\CommunicationConfig;
+use Factfinder\Export\Model\Config\ExportConfig;
+use Omikron\FactFinder\Communication\Client\ClientBuilder;
+use Omikron\FactFinder\Communication\Client\ClientException;
+use Omikron\FactFinder\Communication\Resource\AdapterFactory;
+use Omikron\FactFinder\Communication\Version;
+
+class PushImport
+{
+    private string $pushImportResult;
+
+    public function __construct(
+        private readonly ClientBuilder $clientBuilder,
+        private readonly CredentialsFactory $credentialsFactory,
+        private readonly CommunicationConfig $communicationConfig,
+        private readonly ExportConfig $exportConfig,
+    ) {
+    }
+
+    public function execute(int $storeId): bool
+    {
+        $clientBuilder = $this->clientBuilder
+            ->withServerUrl($this->communicationConfig->getAddress())
+            ->withCredentials($this->credentialsFactory->create());
+
+        $adapterFactory = new AdapterFactory(
+            $clientBuilder,
+            $this->communicationConfig->getVersion(),
+            $this->communicationConfig->getApiVersion()
+        );
+        $importAdapter = $adapterFactory->getImportAdapter();
+        $channel = $this->communicationConfig->getChannel($storeId);
+        $dataTypes = $this->exportConfig->getPushImportDataTypes($storeId);
+
+        if (!$dataTypes) {
+            return false;
+        }
+
+        if ($this->communicationConfig->getVersion() === Version::NG && $importAdapter->running($channel)) {
+            throw new ClientException("Can't start a new import process. Another one is still going");
+        }
+
+        $responses = [];
+
+        foreach ($dataTypes as $dataType) {
+            $responses = [...$responses, ...$importAdapter->import($channel, $dataType)];
+        }
+
+        $this->pushImportResult = $this->prepareListFromPushImportResponses($responses);
+
+        return true;
+    }
+
+    public function getPushImportResult(): string
+    {
+        return $this->pushImportResult;
+    }
+
+    private function prepareListFromPushImportResponses(array $responses): string
+    {
+        return strtolower($this->communicationConfig->getVersion()) === 'ng'
+            ? $this->ngResponse($responses)
+            : $this->standardResponse($responses);
+    }
+
+    private function ngResponse(array $responses): string
+    {
+        $list = '<ul>%s</ul>';
+        $listContent = '';
+
+        foreach ($responses as $response) {
+            $importType = sprintf('<li><b>%s push import type</b></li>', $response['importType']);
+            $statusList = sprintf(
+                '<ul>%s</ul>',
+                implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $response['statusMessages']))
+            );
+            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusList);
+            $importType .= $statusMessages;
+            $listContent .= $importType;
+        }
+
+        return sprintf($list, $listContent);
+    }
+
+    private function standardResponse(array $responses): string
+    {
+        $list = '<ul>%s</ul>';
+        $listContent = '';
+
+        if (!empty($responses['status'])) {
+            $statusList = sprintf(
+                '<ul>%s</ul>',
+                implode('', array_map(fn (string $message): string => sprintf('<li>%s</li>', $message), $responses['status']))
+            );
+
+            $statusMessages = sprintf('<li><i>Status messages</i></li><li>%s</li>', $statusList);
+            $listContent .= $statusMessages;
+        }
+
+        return sprintf($list, $listContent);
+    }
+}

--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -19,7 +19,8 @@ class CommunicationConfig implements ParametersSourceInterface
     private const PATH_DATA_TRANSFER_IMPORT = 'factfinder_export/data_transfer/ff_export_push_import_enabled';
     private const PATH_IS_LOGGING_ENABLED = 'factfinder_export/general/logging_enabled';
 
-    public function __construct(private readonly ScopeConfigInterface $scopeConfig) {
+    public function __construct(private readonly ScopeConfigInterface $scopeConfig)
+    {
     }
 
     public function getChannel(int $scopeId = null): string

--- a/src/Model/Export/Catalog/DataProvider.php
+++ b/src/Model/Export/Catalog/DataProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Catalog;
+
+use Factfinder\Export\Api\Export\DataProviderInterface;
+use Factfinder\Export\Api\Export\ExportEntityInterface;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Framework\ObjectManagerInterface;
+
+class DataProvider implements DataProviderInterface
+{
+    public function __construct(
+        private readonly Products $products,
+        private readonly ObjectManagerInterface $objectManager,
+        private readonly array $fields,
+        private readonly array $entityTypes,
+    ) {
+    }
+
+    /**
+     * @return ExportEntityInterface[]
+     */
+    public function getEntities(): iterable
+    {
+        yield from []; // init generator: Prevent errors in case of an empty product collection
+
+        foreach ($this->products as $product) {
+            yield from $this->entitiesFrom($product)->getEntities();
+        }
+    }
+
+    private function entitiesFrom(ProductInterface $product): DataProviderInterface
+    {
+        $type = $this->entityTypes[$product->getTypeId()] ?? $this->entityTypes[ProductType::DEFAULT_TYPE];
+
+        return $this->objectManager->create($type, ['product' => $product, 'productFields' => $this->fields]); // phpcs:ignore
+    }
+}

--- a/src/Model/Export/Catalog/ProductField/ProductImage.php
+++ b/src/Model/Export/Catalog/ProductField/ProductImage.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Catalog\ProductField;
+
+use Factfinder\Export\Api\Export\FieldInterface;
+use Magento\Catalog\Helper\Image as ImageHelper;
+use Magento\Framework\Model\AbstractModel;
+
+class ProductImage implements FieldInterface
+{
+    public function __construct(
+        private readonly ImageHelper $imageHelper,
+        private readonly string $imageId = 'ff_export_image_url',
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'ImageUrl';
+    }
+
+    public function getValue(AbstractModel $product): string
+    {
+        return $this->imageHelper->init($product, $this->imageId)->getUrl();
+    }
+}

--- a/src/Model/Export/Catalog/Products.php
+++ b/src/Model/Export/Catalog/Products.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Catalog;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Store\Model\StoreManagerInterface;
+use Traversable;
+
+class Products implements \IteratorAggregate
+{
+    public function __construct(
+        private readonly ProductRepositoryInterface $productRepository,
+        private readonly SearchCriteriaBuilder $searchCriteriaBuilder,
+        private readonly StoreManagerInterface $storeManager,
+        private readonly int $batchSize = 300,
+    ) {
+    }
+
+    /**
+     * @return Traversable|ProductInterface[]
+     */
+    public function getIterator(): Traversable
+    {
+        $page = 1;
+
+        while (true) {
+            $query = $this->getQuery($page)->create();
+            $list  = $this->productRepository->getList($query);
+            yield from $list->getItems();
+
+            if ($page * $this->batchSize >= $list->getTotalCount()) {
+                break;
+            }
+
+            $page++;
+        }
+    }
+
+    protected function getQuery(int $page): SearchCriteriaBuilder
+    {
+        return $this->searchCriteriaBuilder
+            ->addFilter('status', Status::STATUS_ENABLED)
+            ->addFilter('store_id', $this->storeManager->getStore()->getId())
+            ->addFilter('visibility', Visibility::VISIBILITY_NOT_VISIBLE, 'neq')
+            ->setPageSize($this->batchSize)
+            ->setCurrentPage($page);
+    }
+}

--- a/src/Model/StoreEmulation.php
+++ b/src/Model/StoreEmulation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\AreaList;
+use Magento\Store\Model\App\Emulation;
+
+class StoreEmulation
+{
+    public function __construct(private readonly Emulation $emulation, private readonly AreaList $areaList)
+    {
+    }
+
+    public function runInStore(int $storeId, callable $proceed)
+    {
+        try {
+            $this->emulation->startEnvironmentEmulation($storeId, Area::AREA_FRONTEND, true);
+            $area = $this->areaList->getArea(Area::AREA_FRONTEND);
+            $area->load(Area::PART_TRANSLATE);
+            $proceed();
+        } finally {
+            $this->emulation->stopEnvironmentEmulation();
+        }
+    }
+}

--- a/src/Service/FeedFileService.php
+++ b/src/Service/FeedFileService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Service;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use \InvalidArgumentException;
+
+class FeedFileService
+{
+    private const FEED_FILENAME_PATTERN = 'export.%type%.%channel%.csv';
+    public function __construct(private readonly Filesystem $fileSystem)
+    {
+    }
+
+    public function getFeedExportFilename(string $exportType, string $channel): string
+    {
+        if (empty($exportType)) {
+            throw new InvalidArgumentException('Export type must not be empty');
+        }
+
+        if (empty($channel)) {
+            throw new InvalidArgumentException('Channel must not be empty');
+        }
+
+        return str_replace(['%type%', '%channel%'], [$exportType, $channel], self::FEED_FILENAME_PATTERN);
+    }
+
+    public function getExportPath(string $fileName): string
+    {
+        return $this->fileSystem->getDirectoryWrite(DirectoryList::VAR_DIR)
+            ->getAbsolutePath('factfinder' . DIRECTORY_SEPARATOR . $fileName);
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -3,7 +3,13 @@
     <preference for="Factfinder\Export\Api\ExporterInterface" type="Factfinder\Export\Model\Exporter" />
     <preference for="Factfinder\Export\Api\Filter\FilterInterface" type="Factfinder\Export\Model\Filter\TextFilter" />
     <preference for="Factfinder\Export\Api\StreamInterface" type="Factfinder\Export\Model\Stream\Csv" />
-
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="factfinderexport-export" xsi:type="object">Factfinder\Export\Console\Command\Export</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Factfinder\Export\Model\Export\Catalog\ExportPreviewDataProvider">
         <arguments>
             <argument name="productFields" xsi:type="array">
@@ -20,12 +26,40 @@
             </argument>
         </arguments>
     </type>
+    <type name="Factfinder\Export\Model\Export\Catalog\DataProvider">
+        <arguments>
+            <argument name="entityTypes" xsi:type="array">
+                <item name="simple" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\SimpleDataProvider</item>
+                <item name="configurable" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\ConfigurableDataProvider</item>
+                <item name="grouped" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\GroupedDataProvider</item>
+                <item name="bundle" xsi:type="string">Factfinder\Export\Model\Export\Catalog\ProductType\BundleDataProvider</item>
+            </argument>
+        </arguments>
+    </type>
+    <type name="Factfinder\Export\Model\Export\Catalog\FieldProvider">
+        <arguments>
+            <argument name="productFields" xsi:type="array">
+                <item name="CategoryPath" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\CategoryPath</item>
+                <item name="Brand" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\Brand</item>
+                <item name="FilterAttributes" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\FilterAttributes</item>
+                <item name="NumericalAttributes" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\NumericalAttributes</item>
+            </argument>
+            <argument name="variantFields" xsi:type="array">
+                <item name="ImageURL" xsi:type="object">Factfinder\Export\Model\Export\Catalog\ProductField\ProductImage</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Factfinder\Export\Model\Export\FeedFactory">
         <arguments>
             <argument name="feedPool" xsi:type="array">
                 <item name="exportPreviewProduct" xsi:type="array">
                     <item xsi:type="string" name="generator">Factfinder\Export\Model\Export\ExportPreviewProductFeed</item>
                     <item xsi:type="string" name="dataProvider">Factfinder\Export\Model\Export\Catalog\ExportPreviewDataProvider</item>
+                    <item xsi:type="string" name="fieldProvider">Factfinder\Export\Model\Export\Catalog\FieldProvider</item>
+                </item>
+                <item name="product" xsi:type="array">
+                    <item xsi:type="string" name="generator">Factfinder\Export\Model\Export\CatalogFeed</item>
+                    <item xsi:type="string" name="dataProvider">Factfinder\Export\Model\Export\Catalog\DataProvider</item>
                     <item xsi:type="string" name="fieldProvider">Factfinder\Export\Model\Export\Catalog\FieldProvider</item>
                 </item>
             </argument>


### PR DESCRIPTION
Create CLI export for products

- Solves issue:
    - FFWEB-2738
- Description:
    - Create CLI export for products
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
