### PR TITLE
FFWEB-2736: HTTP export

### DIFF
--- a/src/Console/Command/Export.php
+++ b/src/Console/Command/Export.php
@@ -25,7 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Export extends Command
 {
-
     public function __construct(
         private readonly StoreManagerInterface $storeManager,
         private readonly FeedGeneratorFactory $feedGeneratorFactory,

--- a/src/Controller/Export/Product.php
+++ b/src/Controller/Export/Product.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Controller\Export;
+
+use Factfinder\Export\Model\Config\CommunicationConfig;
+use Factfinder\Export\Model\Export\FeedFactory as FeedGeneratorFactory;
+use Factfinder\Export\Model\StoreEmulation;
+use Factfinder\Export\Model\Stream\Csv;
+use Factfinder\Export\Service\FeedFileService;
+use Magento\Framework\App\Action\Action;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\Filesystem;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Product extends Action
+{
+    private const FEED_TYPE = 'product';
+
+    public function __construct(
+        Context $context,
+        private readonly CommunicationConfig $communicationConfig,
+        private readonly StoreEmulation $storeEmulation,
+        private readonly FeedGeneratorFactory $feedGeneratorFactory,
+        private readonly FileFactory $fileFactory,
+        private readonly StoreManagerInterface $storeManager,
+        private readonly FeedFileService $feedFileService,
+        private readonly Filesystem $filesystem,
+    ) {
+        parent::__construct($context);
+    }
+
+    public function execute()
+    {
+        $storeId = (int) $this->getRequest()->getParam('store', $this->storeManager->getDefaultStoreView()->getId());
+        $this->storeEmulation->runInStore($storeId, function () {
+            $filename = $this->feedFileService->getFeedExportFilename(self::FEED_TYPE, $this->communicationConfig->getChannel());
+            $stream = new Csv($this->filesystem, "factfinder/$filename");
+            $this->feedGeneratorFactory->create(self::FEED_TYPE)->generate($stream);
+            $this->fileFactory->create($filename, $stream->getContent());
+        });
+    }
+}

--- a/src/Model/Export/BasicAuth.php
+++ b/src/Model/Export/BasicAuth.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class BasicAuth
+{
+    private const CONFIG_PATH_USERNAME = 'factfinder_export/basic_auth/ff_export_auth_user';
+    private const CONFIG_PATH_PASSWORD = 'factfinder_export/basic_auth/ff_export_auth_password';
+
+    public function __construct(private readonly ScopeConfigInterface $scopeConfig)
+    {
+    }
+
+    public function authenticate(string $username, string $password): bool
+    {
+        return strcmp($username, $this->getUsername()) === 0 && strcmp($password, $this->getPassword()) === 0;
+    }
+
+    private function getUsername(): string
+    {
+        return (string) $this->scopeConfig->getValue(self::CONFIG_PATH_USERNAME, ScopeInterface::SCOPE_STORE);
+    }
+
+    private function getPassword(): string
+    {
+        return (string) $this->scopeConfig->getValue(self::CONFIG_PATH_PASSWORD, ScopeInterface::SCOPE_STORE);
+    }
+}

--- a/src/Observer/ExportAuthentication.php
+++ b/src/Observer/ExportAuthentication.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Observer;
+
+use Factfinder\Export\Model\Export\BasicAuth;
+use Magento\Framework\App\ActionFlag;
+use Magento\Framework\App\ActionInterface as Action;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\HTTP\Authentication as Credentials;
+
+/**
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+class ExportAuthentication implements ObserverInterface
+{
+    public function __construct(
+        private readonly ActionFlag $actionFlag,
+        private readonly BasicAuth $authentication,
+        private readonly Credentials $credentials,
+    ) {}
+
+    public function execute(Observer $observer)
+    {
+        if (!$this->authentication->authenticate(...$this->credentials->getCredentials())) {
+            $this->credentials->setAuthenticationFailed('FACT-Finder');
+            $this->actionFlag->set('', Action::FLAG_NO_DISPATCH, true);
+        }
+    }
+}

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -12,6 +12,7 @@
             <include path="Factfinder_Export::system/general.xml" />
             <include path="Factfinder_Export::system/data_transfer.xml" />
             <include path="Factfinder_Export::system/export.xml" />
+            <include path="Factfinder_Export::system/basic_auth.xml" />
         </section>
     </system>
 </config>

--- a/src/etc/adminhtml/system/basic_auth.xml
+++ b/src/etc/adminhtml/system/basic_auth.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="basic_auth" translate="label" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
+        <label>HTTP Export</label>
+        <field id="ff_export_auth_user" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>Basic Auth User</label>
+        </field>
+
+        <field id="ff_export_auth_password" translate="label" type="obscure" sortOrder="30" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>Basic Auth Password</label>
+            <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+        </field>
+    </group>
+</include>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -13,6 +13,9 @@
                 <ff_export_upload_port>21</ff_export_upload_port>
                 <ff_export_upload_dir>/</ff_export_upload_dir>
             </data_transfer>
+            <basic_auth>
+                <ff_export_auth_password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
+            </basic_auth>
         </factfinder_export>
     </default>
 </config>

--- a/src/etc/frontend/events.xml
+++ b/src/etc/frontend/events.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="controller_action_predispatch_factfinderexport_export_product">
+        <observer name="ff_export_basic_authentication" instance="Factfinder\Export\Observer\ExportAuthentication"/>
+    </event>
+</config>

--- a/src/etc/frontend/routes.xml
+++ b/src/etc/frontend/routes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
+    <router id="standard">
+        <route id="factfinderexport" frontName="factfinder-export">
+            <module name="Factfinder_Export" />
+        </route>
+    </router>
+</config>


### PR DESCRIPTION


- Solves issue:
    - FFWEB-2736
- Description:
    - Add HTTP export type with basic auth protection
- Tested with Magento editions/versions:
    -  2.4.6
- Tested with PHP versions:
    - 8.1
