### PR TITLE
FFWEB-2739: Add configuration files for cron export

### DIFF
--- a/src/Model/Adminhtml/System/Config/Backend/Feed/Frequency.php
+++ b/src/Model/Adminhtml/System/Config/Backend/Feed/Frequency.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Adminhtml\System\Config\Backend\Feed;
+
+use Magento\Cron\Model\Config\Source\Frequency as CoreFrequency;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+
+class Frequency extends Value
+{
+    private const PATH_CRON_TIME = 'ff_export_cron_time';
+    private const CRON_STRING_PATH = 'crontab/default/jobs/factfinder_export_feed_export/schedule/cron_expr';
+
+    protected WriterInterface $configWriter;
+
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        WriterInterface $configWriter,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+        $this->configWriter = $configWriter;
+    }
+
+    public function afterSave(): Value
+    {
+        $time = $this->getFieldsetDataValue(self::PATH_CRON_TIME);
+        $frequency = $this->getValue();
+        $frequencyWeekly = CoreFrequency::CRON_WEEKLY;
+        $frequencyMonthly = CoreFrequency::CRON_MONTHLY;
+
+        $cronExprArray  = [
+            (int) $time[1],
+            (int) $time[0],
+            ($frequency == $frequencyMonthly) ? '1' : '*',
+            '*',
+            ($frequency == $frequencyWeekly) ? '1' : '*',
+        ];
+        $cronExprString = join(' ', $cronExprArray);
+
+        try {
+            $this->configWriter->save(self::CRON_STRING_PATH, $cronExprString);
+        } catch (\Exception $e) {
+            throw new LocalizedException(__('Unable to save the cron expression.'), $e);
+        }
+
+        return $this;
+    }
+}

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -13,6 +13,7 @@
             <include path="Factfinder_Export::system/data_transfer.xml" />
             <include path="Factfinder_Export::system/export.xml" />
             <include path="Factfinder_Export::system/basic_auth.xml" />
+            <include path="Factfinder_Export::system/cron.xml" />
         </section>
     </system>
 </config>

--- a/src/etc/adminhtml/system/cron.xml
+++ b/src/etc/adminhtml/system/cron.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="configurable_cron" translate="label" sortOrder="70" showInDefault="1" showInWebsite="0" showInStore="0">
+        <label>Cron Schedule</label>
+        <field id="ff_export_cron_enabled" translate="label" type="select" sortOrder="120" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>Generate export files(s) automatically</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+        </field>
+        <field id="ff_export_cron_time" translate="label" type="time" sortOrder="140" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>Start Time</label>
+            <depends>
+                <field id="ff_export_cron_enabled">1</field>
+            </depends>
+        </field>
+        <field id="ff_export_cron_frequency" translate="label" type="select" sortOrder="150" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>Cron execution frequency</label>
+            <source_model>Magento\Cron\Model\Config\Source\Frequency</source_model>
+            <backend_model>Factfinder\Export\Model\Adminhtml\System\Config\Backend\Feed\Frequency</backend_model>
+            <depends>
+                <field id="ff_export_cron_enabled">1</field>
+            </depends>
+        </field>
+    </group>
+</include>

--- a/src/etc/crontab.xml
+++ b/src/etc/crontab.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="default">
+        <job name="factfinder_export_feed_export" instance="FFProductExportCron" method="execute">
+            <schedule>0 1 * * *</schedule>
+        </job>
+    </group>
+</config>

--- a/src/etc/crontab/di.xml
+++ b/src/etc/crontab/di.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <virtualType name="FFProductExportCron" type="Factfinder\Export\Cron\Feed">
+        <arguments>
+            <argument name="feedType" xsi:type="string">product</argument>
+        </arguments>
+    </virtualType>
+</config>


### PR DESCRIPTION
Add configuration files for cron export

- Solves issue:
    - FFWEB-2739
- Description:
    -  Add configuration files for cron export
- Tested with Magento editions/versions:
    - 2.4.6
- Tested with PHP versions:
    -  8.1
