### PR TITLE
FFWEB-2739: Add business logic for cron export

### DIFF
--- a/src/Cron/Feed.php
+++ b/src/Cron/Feed.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Cron;
+
+use Factfinder\Export\Model\Api\PushImport;
+use Factfinder\Export\Model\Config\CommunicationConfig;
+use Factfinder\Export\Model\Export\FeedFactory as FeedGeneratorFactory;
+use Factfinder\Export\Model\FtpUploader;
+use Factfinder\Export\Model\StoreEmulation;
+use Factfinder\Export\Model\Stream\Csv;
+use Factfinder\Export\Service\FeedFileService;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Filesystem;
+use Magento\Store\Model\StoreManagerInterface;
+
+class Feed
+{
+    private const PATH_CONFIGURABLE_CRON_IS_ENABLED = 'factfinder_export/configurable_cron/ff_export_cron_enabled';
+
+    /**
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly StoreManagerInterface $storeManager,
+        private readonly FeedGeneratorFactory $feedGeneratorFactory,
+        private readonly StoreEmulation $storeEmulation,
+        private readonly FtpUploader $ftpUploader,
+        private readonly CommunicationConfig $communicationConfig,
+        private readonly PushImport $pushImport,
+        private readonly FeedFileService $feedFileService,
+        private readonly Filesystem $filesystem,
+        private readonly string $feedType,
+    ) {
+    }
+
+    public function execute(): void
+    {
+        if (!$this->scopeConfig->isSetFlag(self::PATH_CONFIGURABLE_CRON_IS_ENABLED)) {
+            return;
+        }
+
+        foreach ($this->storeManager->getStores() as $store) {
+            $this->storeEmulation->runInStore((int) $store->getId(), function () use ($store) {
+                $storeId = (int) $store->getId();
+
+                if ($this->communicationConfig->isChannelEnabled($storeId)) {
+                    $filename = $this->feedFileService->getFeedExportFilename(
+                        $this->feedType,
+                        $this->communicationConfig->getChannel()
+                    );
+                    $stream = new Csv($this->filesystem, "factfinder/$filename");
+                    $this->feedGeneratorFactory->create($this->feedType)->generate($stream);
+                    $this->ftpUploader->upload($filename, $stream);
+
+                    if ($this->communicationConfig->isPushImportEnabled($storeId)) {
+                        $this->pushImport->execute($storeId);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/Model/Config/CommunicationConfig.php
+++ b/src/Model/Config/CommunicationConfig.php
@@ -23,7 +23,7 @@ class CommunicationConfig implements ParametersSourceInterface
     {
     }
 
-    public function getChannel(int $scopeId = null): string
+    public function getChannel(?int $scopeId = null): string
     {
         return (string) $this->scopeConfig->getValue(self::PATH_CHANNEL, ScopeInterface::SCOPE_STORES, $scopeId);
     }
@@ -33,12 +33,12 @@ class CommunicationConfig implements ParametersSourceInterface
         return (string) $this->scopeConfig->getValue(self::PATH_ADDRESS, ScopeInterface::SCOPE_STORES);
     }
 
-    public function isChannelEnabled(int $scopeId = null): bool
+    public function isChannelEnabled(?int $scopeId = null): bool
     {
         return $this->scopeConfig->isSetFlag(self::PATH_IS_ENABLED, ScopeInterface::SCOPE_STORES, $scopeId);
     }
 
-    public function isPushImportEnabled(int $scopeId = null): bool
+    public function isPushImportEnabled(?int $scopeId = null): bool
     {
         return $this->scopeConfig->isSetFlag(self::PATH_DATA_TRANSFER_IMPORT, ScopeInterface::SCOPE_STORES, $scopeId);
     }
@@ -69,10 +69,6 @@ class CommunicationConfig implements ParametersSourceInterface
 
     private function getServerUrl(): string
     {
-//        if ($this->scopeConfig->isSetFlag(self::PATH_USE_PROXY, ScopeInterface::SCOPE_STORES)) {
-//            return $this->urlBuilder->getUrl('', ['_direct' => Router::FRONT_NAME]);
-//        }
-
         return $this->getAddress();
     }
 }


### PR DESCRIPTION
- Solves issue:
    - FFWEB-2739
- Description:
    - Add business logic for cron export
- Tested with Magento editions/versions:
    - 2.4.6
- Tested with PHP versions:
    - 8.1
