### PR TITLE
FFWEB-2743: Add export CMS feature

### DIFF
--- a/src/Model/Config/CmsConfig.php
+++ b/src/Model/Config/CmsConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Config;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+class CmsConfig
+{
+    private const PATH_DISABLE_CMS_PAGES = 'factfinder_export/cms_export/ff_export_cms_blacklist';
+
+    public function __construct(private readonly ScopeConfigInterface $scopeConfig)
+    {
+    }
+
+    public function getCmsBlacklist(int $scopeCode = null): array
+    {
+        $pages = (string) $this->scopeConfig->getValue(self::PATH_DISABLE_CMS_PAGES, 'store', $scopeCode);
+
+        return array_filter(explode(',', $pages));
+    }
+}

--- a/src/Model/Export/Cms/DataProvider.php
+++ b/src/Model/Export/Cms/DataProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms;
+
+use Factfinder\Export\Api\Export\DataProviderInterface;
+use Factfinder\Export\Api\Export\ExportEntityInterface;
+
+class DataProvider implements DataProviderInterface
+{
+    public function __construct(
+        private readonly Pages $pages,
+        private readonly PageFactory $pageFactory,
+        private readonly array $fields,
+    ) {
+    }
+
+    /**
+     * @return ExportEntityInterface[]
+     */
+    public function getEntities(): iterable
+    {
+        yield from [];
+
+        foreach ($this->pages as $page) {
+            yield $this->pageFactory->create(['page' => $page, 'pageFields' => $this->fields]);
+        }
+    }
+}

--- a/src/Model/Export/Cms/Field/Content.php
+++ b/src/Model/Export/Cms/Field/Content.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms\Field;
+
+use Factfinder\Export\Api\Export\FieldInterface;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Email\Model\Template\Filter;
+use Magento\Framework\Model\AbstractModel;
+
+class Content implements FieldInterface
+{
+    public function __construct(private readonly Filter $filter)
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'Content';
+    }
+
+    /**
+     * @param PageInterface $page
+     *
+     * @return string
+     */
+    public function getValue(AbstractModel $page): string
+    {
+        $filteredContent  = $this->filter->filter($page->getContent());
+        $stylesAndScripts = '#\<(?:style|script)[^\>]*\>[^\<]*\</(?:style|script)\>#siU';
+        $variables = '#{{[^}]*}}#siU';
+        $returns = '#<br\s?\/?>#';
+        $whitespaces = '#(\s|&nbsp;)+#s';
+
+        return preg_replace([$stylesAndScripts, $variables, $returns, $whitespaces], ' ', $filteredContent);
+    }
+}

--- a/src/Model/Export/Cms/Field/Deeplink.php
+++ b/src/Model/Export/Cms/Field/Deeplink.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms\Field;
+
+use Factfinder\Export\Api\Export\FieldInterface;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Model\AbstractModel;
+
+class Deeplink implements FieldInterface
+{
+    public function __construct(
+        private readonly UrlInterface $urlBuilder,
+        private readonly StoreManagerInterface $storeManager,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'Deeplink';
+    }
+
+    /**
+     * @param PageInterface $page
+     *
+     * @return string
+     */
+    public function getValue(AbstractModel $page): string
+    {
+        $this->urlBuilder->setScope($this->storeManager->getStore()->getId());
+
+        return $this->urlBuilder->getUrl(null, ['_direct' => $page->getIdentifier()]);
+    }
+}

--- a/src/Model/Export/Cms/Field/Image.php
+++ b/src/Model/Export/Cms/Field/Image.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms\Field;
+
+use Factfinder\Export\Api\Export\FieldInterface;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Email\Model\Template\Filter;
+use Magento\Framework\Model\AbstractModel;
+
+class Image implements FieldInterface
+{
+    public function __construct(private readonly Filter $filter)
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'Image';
+    }
+
+    /**
+     * @param PageInterface $page
+     *
+     * @return string
+     */
+    public function getValue(AbstractModel $page): string
+    {
+        $pattern = '#https?://[^/\s]+/\S+\.(jpe?g|png|gif)#i';
+        preg_match($pattern, $this->filter->filter((string) $page->getContent()), $result);
+
+        return $result[0] ?? '';
+    }
+}

--- a/src/Model/Export/Cms/Page.php
+++ b/src/Model/Export/Cms/Page.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms;
+
+use Factfinder\Export\Api\Export\ExportEntityInterface;
+use Factfinder\Export\Api\Export\FieldInterface;
+use Magento\Cms\Api\Data\PageInterface;
+
+class Page implements ExportEntityInterface
+{
+    public function __construct(
+        private readonly PageInterface $page,
+        private readonly array $pageFields = [],
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return (int) $this->page->getId();
+    }
+
+    public function toArray(): array
+    {
+        $data = [
+            'PageId' => (string) $this->getId(),
+            'Master' => (string) $this->getId(),
+            'Identifier' => (string) $this->page->getIdentifier(),
+            'Title' => (string) $this->page->getTitle(),
+            'ContentHeading' => (string) $this->page->getContentHeading(),
+            'MetaKeywords' => (string) $this->page->getMetaKeywords(),
+            'MetaDescription' => (string) $this->page->getMetaDescription(),
+        ];
+
+        return array_reduce(
+            $this->pageFields,
+            fn (array $result, FieldInterface $field): array =>
+                [$field->getName() => $field->getValue($this->page)] + $result,
+            $data
+        );
+    }
+}

--- a/src/Model/Export/Cms/Pages.php
+++ b/src/Model/Export/Cms/Pages.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms;
+
+use Factfinder\Export\Model\Config\CmsConfig;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Cms\Api\PageRepositoryInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use Traversable;
+
+class Pages implements \IteratorAggregate
+{
+    public function __construct(
+        private readonly PageRepositoryInterface $pageRepository,
+        private readonly SearchCriteriaBuilder   $searchCriteriaBuilder,
+        private readonly CmsConfig               $cmsConfig,
+        private readonly StoreManagerInterface   $storeManager,
+    ) {
+    }
+
+    /**
+     * @return Traversable|PageInterface[]
+     * @throws LocalizedException
+     */
+    public function getIterator(): Traversable
+    {
+        $query = $this->getQuery()->create();
+        yield from $this->pageRepository->getList($query)->getItems();
+    }
+
+    protected function getQuery(): SearchCriteriaBuilder
+    {
+        $blacklist = $this->cmsConfig->getCmsBlacklist();
+
+        if ($blacklist) {
+            $this->searchCriteriaBuilder->addFilter('identifier', $blacklist, 'nin');
+        }
+
+        $inStores  = [Store::DEFAULT_STORE_ID, (int) $this->storeManager->getStore()->getId()];
+
+        return $this->searchCriteriaBuilder->addFilter('store_id', $inStores, 'in');
+    }
+}

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -12,6 +12,7 @@
             <include path="Factfinder_Export::system/general.xml" />
             <include path="Factfinder_Export::system/data_transfer.xml" />
             <include path="Factfinder_Export::system/export.xml" />
+            <include path="Factfinder_Export::system/cms.xml" />
             <include path="Factfinder_Export::system/basic_auth.xml" />
             <include path="Factfinder_Export::system/cron.xml" />
         </section>

--- a/src/etc/adminhtml/system/cms.xml
+++ b/src/etc/adminhtml/system/cms.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="cms_export" translate="label" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+        <label>CMS Export Settings</label>
+        <field id="ff_export_cms_blacklist" translate="label comment" type="multiselect" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="5">
+            <label>Pages Blacklist</label>
+            <comment>Selected pages will not be exported</comment>
+            <source_model>Magento\Cms\Model\Config\Source\Page</source_model>
+            <can_be_empty>1</can_be_empty>
+        </field>
+    </group>
+</include>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -6,6 +6,8 @@
                 <is_enabled>0</is_enabled>
                 <logging_enabled>0</logging_enabled>
                 <password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
+                <version>7.3</version>
+                <ff_api_version>v4</ff_api_version>
             </general>
             <data_transfer>
                 <ff_export_upload_password backend_model="Magento\Config\Model\Config\Backend\Encrypted" />

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -62,6 +62,15 @@
                     <item xsi:type="string" name="dataProvider">Factfinder\Export\Model\Export\Catalog\DataProvider</item>
                     <item xsi:type="string" name="fieldProvider">Factfinder\Export\Model\Export\Catalog\FieldProvider</item>
                 </item>
+                <item name="cms" xsi:type="array">
+                    <item xsi:type="string" name="generator">Factfinder\Export\Model\Export\CmsFeed</item>
+                    <item xsi:type="string" name="dataProvider">Factfinder\Export\Model\Export\Cms\DataProvider</item>
+                    <item xsi:type="array" name="fieldProvider">
+                        <item name="Content" xsi:type="object">Factfinder\Export\Model\Export\Cms\Field\Content</item>
+                        <item name="Deeplink" xsi:type="object">Factfinder\Export\Model\Export\Cms\Field\Deeplink</item>
+                        <item name="Image" xsi:type="object">Factfinder\Export\Model\Export\Cms\Field\Image</item>
+                    </item>
+                </item>
             </argument>
         </arguments>
     </type>
@@ -84,6 +93,19 @@
                 <item name="FilterAttributes" xsi:type="string">FilterAttributes</item>
                 <item name="HasVariants" xsi:type="string">HasVariants</item>
                 <item name="NumericalAttributes" xsi:type="string">NumericalAttributes</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Factfinder\Export\Model\Export\CmsFeed" type="Factfinder\Export\Model\Export\Feed">
+        <arguments>
+            <argument name="columns" xsi:type="array">
+                <item name="PageId" xsi:type="string">PageId</item>
+                <item name="Master" xsi:type="string">Master</item>
+                <item name="Identifier" xsi:type="string">Identifier</item>
+                <item name="Title" xsi:type="string">Title</item>
+                <item name="ContentHeading" xsi:type="string">ContentHeading</item>
+                <item name="MetaKeywords" xsi:type="string">MetaKeywords</item>
+                <item name="MetaDescription" xsi:type="string">MetaDescription</item>
             </argument>
         </arguments>
     </virtualType>
@@ -117,6 +139,16 @@
     <type name="Factfinder\Export\Model\FtpUploader">
         <arguments>
             <argument name="client" xsi:type="object">Magento\Framework\Filesystem\Io\Ftp</argument>
+        </arguments>
+    </type>
+    <type name="Factfinder\Export\Model\Export\Cms\Field\Content">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Email\Model\Template\Filter\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Factfinder\Export\Model\Export\Cms\Field\Image">
+        <arguments>
+            <argument name="filter" xsi:type="object">Magento\Email\Model\Template\Filter\Proxy</argument>
         </arguments>
     </type>
 </config>


### PR DESCRIPTION
- Solves issue:
    - FFWEB-2743
- Description:
    - Add export CMS feature with basic config blacklist pages
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
