### PR TITLE
FFWEB-2758: Add missing test for cms export

### DIFF
--- a/src/Test/Unit/Model/Export/Cms/Field/ContentTest.php
+++ b/src/Test/Unit/Model/Export/Cms/Field/ContentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms\Field;
+
+use Magento\Email\Model\Template\Filter;
+use PHPUnit\Framework\MockObject\MockObject;
+use Magento\Framework\Model\AbstractModel;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Content
+ */
+class ContentTest extends TestCase
+{
+    /** @var MockObject|Filter */
+    private $filterMock;
+
+    /** @var Content */
+    private $contentField;
+
+    /** @var string */
+    private $content = '<style>some styles</style> Page Content&nbsp;<script type="text/javascript">javascript magic</script>{{}}';
+
+    public function test_replace_unwanted_expressions()
+    {
+        $pageMock = $this->getMockBuilder(AbstractModel::class)
+                         ->disableOriginalConstructor()
+                         ->addMethods(['getContent'])
+                         ->getMock();
+        $pageMock->method('getContent')->willReturn($this->content);
+        $filtered = $this->contentField->getValue($pageMock);
+        $this->assertFalse(strpos($filtered, 'style'), 'Content should be cleared from \<style\> occurrences');
+        $this->assertFalse(strpos($filtered, 'style'), 'Content should be cleared from \<script\> occurrences');
+        $this->assertFalse(strpos($filtered, '&nbsp;'), 'Content should be cleared from @nbsp; occurrences');
+    }
+
+    protected function setUp(): void
+    {
+        $this->filterMock   = $this->createConfiguredMock(Filter::class, ['filter' => $this->content]);
+        $this->contentField = new Content($this->filterMock);
+    }
+}

--- a/src/Test/Unit/Model/Export/Cms/Field/DeeplinkTest.php
+++ b/src/Test/Unit/Model/Export/Cms/Field/DeeplinkTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms\Field;
+
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Deeplink
+ */
+class DeeplinkTest extends TestCase
+{
+    /** @var MockObject|UrlInterface */
+    private $urlBuilderMock;
+
+    /** @var MockObject|StoreManagerInterface */
+    private $storeManagerMock;
+
+    /** @var Deeplink */
+    private $deeplinkField;
+
+    public function test_url_builder_should_be_called_with_correct_route_parameters()
+    {
+        $pageMock = $this->getMockBuilder(AbstractModel::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getIdentifier'])
+            ->getMock();
+        $pageMock->method('getIdentifier')->willReturn('test-page');
+        $this->urlBuilderMock->expects($this->once())->method('getUrl')->with($this->anything(), ['_direct' => 'test-page'])->willReturn('some address');
+        $this->deeplinkField->getValue($pageMock);
+    }
+
+    protected function setUp(): void
+    {
+        $this->urlBuilderMock   = $this->createMock(UrlInterface::class);
+        $this->storeManagerMock = $this->createConfiguredMock(StoreManagerInterface::class, [
+            'getStore' => $this->createMock(StoreInterface::class),
+        ]);
+        $this->deeplinkField = new Deeplink($this->urlBuilderMock, $this->storeManagerMock);
+    }
+}

--- a/src/Test/Unit/Model/Export/Cms/Field/ImageTest.php
+++ b/src/Test/Unit/Model/Export/Cms/Field/ImageTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Factfinder\Export\Model\Export\Cms\Field;
+
+use Magento\Email\Model\Template\Filter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\Model\AbstractModel;
+
+/**
+ * @covers Image
+ */
+class ImageTest extends TestCase
+{
+    /** @var MockObject|Filter */
+    private $filterMock;
+
+    /** @var Image */
+    private $imageField;
+
+    /** @var string */
+    private $content = 'Some Cms page with Image <img scr="http://magento-test.factfinder.de/media/image/cms.png" />';
+
+    public function test_image_url_should_be_extracted()
+    {
+        $pageMock = $this->getMockBuilder(AbstractModel::class)
+                         ->disableOriginalConstructor()
+                         ->addMethods(['getContent'])
+                         ->getMock();
+        $pageMock->method('getContent')->willReturn($this->content);
+        $imageUrl = $this->imageField->getValue($pageMock);
+        $this->assertSame('http://magento-test.factfinder.de/media/image/cms.png', $imageUrl);
+    }
+
+    protected function setUp(): void
+    {
+        $this->filterMock = $this->createConfiguredMock(Filter::class, ['filter' => $this->content]);
+        $this->imageField = new Image($this->filterMock);
+    }
+}

--- a/src/Test/Unit/Service/FeedFileServiceTest.php
+++ b/src/Test/Unit/Service/FeedFileServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Factfinder\Export\Service;
+
+use Magento\Framework\Filesystem;
+use PHPUnit\Framework\TestCase;
+use \InvalidArgumentException;
+
+/**
+ * @covers FeedFileService
+ */
+class FeedFileServiceTest extends TestCase
+{
+    private FeedFileService $feedFileService;
+
+    /**
+     * @dataProvider validDataProvider
+     * @throws \Exception
+     */
+    public function test_will_return_filename(string $exportType, string $channel, string $expected)
+    {
+        $result = $this->feedFileService->getFeedExportFilename($exportType, $channel);
+        $this->assertSame($expected, $result);
+    }
+
+    public function test_will_throw_exception_on_empty_export_type()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Export type must not be empty');
+        $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('', 'test_channel'));
+    }
+
+    public function test_will_throw_exception_on_empty_export_channel()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Channel must not be empty');
+        $this->assertSame('export.test_type.test_channel.csv', $this->feedFileService->getFeedExportFilename('test_type', ''));
+    }
+
+    public static function validDataProvider(): array
+    {
+        return [
+            [
+                'test_type', 'test_channel', 'export.test_type.test_channel.csv'
+            ]
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->feedFileService = new FeedFileService($this->createMock(Filesystem::class));
+    }
+}


### PR DESCRIPTION
- Solves issue:
    - FFWEB-2758
- Description:
    - Add missing test for cms export
- Tested with Magento editions/versions:
    - For example: 2.4.6
- Tested with PHP versions:
    - For example: 8.1
